### PR TITLE
fix: export `RegisterOptions` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -439,6 +439,7 @@ class UCI {
 }
 
 export default UCI;
+export type { RegisterOptions };
 export type {
   Events,
   GoOptions,


### PR DESCRIPTION
## Summary

- export `RegisterOptions` from `src/index.ts` so consumers can reference the type when wrapping `register()`

closes #22