### PR TITLE
release: @echecs/uci@4.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [4.0.2] - 2026-04-16
+
+### Fixed
+
+- Exported `RegisterOptions` type — consumers can now reference it when wrapping
+  `register()`
+
 ## [4.0.1] - 2026-04-09
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Named types are exported directly from the package:
 
 ```typescript
 import UCI, { type GoOptions, type Events } from '@echecs/uci';
-// Also available: ID, InfoCommand, Option, Score
+// Also available: ID, InfoCommand, Option, RegisterOptions, Score
 ```
 
 ## Quick Start

--- a/package.json
+++ b/package.json
@@ -82,5 +82,5 @@
   },
   "type": "module",
   "types": "dist/index.d.ts",
-  "version": "4.0.1"
+  "version": "4.0.2"
 }


### PR DESCRIPTION
## Summary

- bump version to 4.0.2
- add changelog entry for exported `RegisterOptions` type
- mention `RegisterOptions` in README import comment

once merged, CI will publish to npm. tag `v4.0.2` will be pushed after merge.