### PR TITLE
release: @echecs/uci@4.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [4.1.0] - 2026-04-26
+
+### Changed
+
+- Upgraded `emittery` from 1.1.0 to 2.0.0 — adapted internally with no breaking
+  changes to the public API
+- Minimum Node.js version raised from 20 to 22 (required by emittery v2)
+
 ## [4.0.2] - 2026-04-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -83,5 +83,5 @@
   },
   "type": "module",
   "types": "dist/index.d.ts",
-  "version": "4.0.2"
+  "version": "4.1.0"
 }


### PR DESCRIPTION
## Summary

- upgraded `emittery` from 1.1.0 to 2.0.0 — adapted internally with no breaking changes to the public API
- minimum Node.js version raised from 20 to 22 (required by emittery v2)