### PR TITLE
chore: use explicit lint-staged glob and fix typedoc config

### DIFF
--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,5 +1,5 @@
 export default {
-  '*': ['prettier --write --ignore-unknown'],
+  '*.(css|js|json|jsx|md|mjs|mts|ts|tsx|yml|yaml)': ['prettier --write'],
   '*.(js|jsx|mjs|mts|ts|tsx)': [
     'eslint --fix --max-warnings 0 --no-warn-ignored',
   ],

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,5 +1,5 @@
 {
-  "entryPoints": ["src/index.ts", "src/types.ts"],
+  "entryPoints": ["src/index.ts"],
   "excludeInternal": false,
   "excludePrivate": true,
   "excludeProtected": false,


### PR DESCRIPTION
two config cleanups:

- **lint-staged**: replaces `'*': ['prettier --write --ignore-unknown']` with explicit file extension glob `'*.(css|js|json|jsx|md|mjs|mts|ts|tsx|yml|yaml)': ['prettier --write']` to match the canonical form documented in the workspace AGENTS.md
- **typedoc**: updates `typedoc.json` to match the canonical config used across all other `@echecs/*` packages