### PR TITLE
chore: remove unnecessary main field

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "wrapper"
   ],
   "license": "MIT",
-  "main": "dist/index.js",
   "name": "@echecs/uci",
   "packageManager": "pnpm@10.33.0",
   "repository": {


### PR DESCRIPTION
ESM-only package with exports — main is a CJS-era field that is not needed