### PR TITLE
chore: normalize types field path

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,6 +81,6 @@
     "test:watch": "pnpm run test --watch"
   },
   "type": "module",
-  "types": "dist/index.d.ts",
+  "types": "./dist/index.d.ts",
   "version": "4.1.0"
 }


### PR DESCRIPTION
uses relative ./dist/index.d.ts path consistently across all packages