### PR TITLE
docs: link SPEC.md from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Coverage](https://codecov.io/gh/echecsjs/uci/branch/main/graph/badge.svg)](https://codecov.io/gh/echecsjs/uci)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 [![API Docs](https://img.shields.io/badge/API-docs-blue.svg)](https://uci.echecs.dev/)
+[![Spec](https://img.shields.io/badge/Spec-UCI-green.svg)](SPEC.md)
 
 **UCI** is a TypeScript wrapper for the
 [Universal Chess Interface](https://www.wbec-ridderkerk.nl/html/UCIProtocol.html)


### PR DESCRIPTION
adds a badge linking to the specification reference