### PR TITLE
chore: add missing publishConfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,9 @@
   "license": "MIT",
   "name": "@echecs/uci",
   "packageManager": "pnpm@10.33.0",
+  "publishConfig": {
+    "access": "public"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/echecsjs/uci.git"


### PR DESCRIPTION
adds `publishConfig.access: public` — was missing, which would cause npm to publish as restricted by default