### PR TITLE
chore: align @types/node to ^25.9.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "description": "Universal Chess Interface (UCI) wrapper for Node.js. Spawns and communicates with UCI chess engines (Stockfish, Komodo, etc.) via a typed event-emitter API.",
   "devDependencies": {
     "@eslint/js": "^10.0.1",
-    "@types/node": "^25.5.0",
+    "@types/node": "^25.9.1",
     "@typescript-eslint/parser": "^8.60.0",
     "@vitest/coverage-v8": "^4.1.7",
     "@vitest/eslint-plugin": "^1.6.18",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.4.0)
       '@types/node':
-        specifier: ^25.5.0
+        specifier: ^25.9.1
         version: 25.9.1
       '@typescript-eslint/parser':
         specifier: ^8.60.0


### PR DESCRIPTION
aligns `@types/node` version with the rest of the monorepo